### PR TITLE
Only Calculate Intersections when needed

### DIFF
--- a/src/GUI/GraphPanel.java
+++ b/src/GUI/GraphPanel.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 
 public class GraphPanel extends JPanel {
     private final List<ParametricFunction> functions = new ArrayList<>();
-    List<Vector2D> intersections = new ArrayList<>();
+    List<Vector2D> intersections;
     private ParametricExpression parametricExpression = null;
     private Vector2D offset = new Vector2D(0,0);
     private Vector2D lastMousePosition = new Vector2D(0,0);


### PR DESCRIPTION
This fix introduces that the intersections will only be calculated when functions get added, recalculated, deleted, or derived. Not only is this less computing intensive it also fixes the flickering of critical (Intersections where Graphs only touch each other, especially at the root of the system) intersection points while moving or zooming.